### PR TITLE
feat: add Hermes Agent as native spawn target

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ clawteam board attach my-team   # Linux/macOS/WSL with tmux
 | [Claude Code](https://claude.ai/claude-code) | `clawteam spawn claude --team ...` | Full support |
 | [Codex](https://openai.com/codex) | `clawteam spawn codex --team ...` | Full support |
 | [nanobot](https://github.com/HKUDS/nanobot) | `clawteam spawn nanobot --team ...` | Full support |
-| [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `clawteam spawn hermes --team ...` | Full support |
+| [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `clawteam spawn hermes --team ...` | Full support (tmux + subprocess) |
 | [Cursor](https://cursor.com) | `clawteam spawn subprocess cursor --team ...` | Experimental |
 | Custom scripts | `clawteam spawn subprocess python --team ...` | Full support |
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/python-≥3.10-blue?logo=python&logoColor=white" alt="Python">
-  <img src="https://img.shields.io/badge/agents-OpenClaw_%7C_Claude_Code_%7C_Codex_%7C_nanobot-blueviolet" alt="Agents">
+  <img src="https://img.shields.io/badge/agents-OpenClaw_%7C_Claude_Code_%7C_Codex_%7C_Hermes_%7C_nanobot-blueviolet" alt="Agents">
   <img src="https://img.shields.io/badge/transport-File_%7C_ZeroMQ_P2P-orange" alt="Transport">
   <img src="https://img.shields.io/badge/version-0.3.0-teal" alt="Version">
 </p>
@@ -35,7 +35,7 @@
 
 You set the goal. The agent swarm handles the rest — spawning workers, splitting tasks, coordinating, and merging results.
 
-Works with [OpenClaw](https://openclaw.ai) (default), [Claude Code](https://claude.ai/claude-code), [Codex](https://openai.com/codex), [nanobot](https://github.com/HKUDS/nanobot), [Cursor](https://cursor.com), and any CLI agent.
+Works with [OpenClaw](https://openclaw.ai) (default), [Claude Code](https://claude.ai/claude-code), [Codex](https://openai.com/codex), [Hermes Agent](https://github.com/NousResearch/hermes-agent), [nanobot](https://github.com/HKUDS/nanobot), [Cursor](https://cursor.com), and any CLI agent.
 
 ## Platform Support
 
@@ -141,6 +141,7 @@ clawteam board attach my-team   # Linux/macOS/WSL with tmux
 | [Claude Code](https://claude.ai/claude-code) | `clawteam spawn claude --team ...` | Full support |
 | [Codex](https://openai.com/codex) | `clawteam spawn codex --team ...` | Full support |
 | [nanobot](https://github.com/HKUDS/nanobot) | `clawteam spawn nanobot --team ...` | Full support |
+| [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `clawteam spawn hermes --team ...` | Full support |
 | [Cursor](https://cursor.com) | `clawteam spawn subprocess cursor --team ...` | Experimental |
 | Custom scripts | `clawteam spawn subprocess python --team ...` | Full support |
 

--- a/clawteam/spawn/adapters.py
+++ b/clawteam/spawn/adapters.py
@@ -48,11 +48,14 @@ class NativeCliAdapter:
                 final_command.append("--yolo")
 
         if is_hermes_command(normalized_command):
-            # Hermes: ensure 'chat' subcommand, pass prompt via -q, session via --continue
+            # Hermes: ensure 'chat' subcommand, tag as tool-sourced so clawteam
+            # spawns don't pollute the user's session list, pass prompt via -q.
+            # Do NOT pass --continue -- Hermes --continue resumes EXISTING sessions
+            # only; fresh spawns auto-generate a session ID.
             if len(final_command) < 2 or final_command[1] != "chat":
                 final_command.insert(1, "chat")
-            if agent_name and "--continue" not in final_command:
-                final_command.extend(["--continue", agent_name])
+            if "--source" not in final_command:
+                final_command.extend(["--source", "tool"])
             if prompt:
                 final_command.extend(["-q", prompt])
         elif is_kimi_command(normalized_command):

--- a/clawteam/spawn/adapters.py
+++ b/clawteam/spawn/adapters.py
@@ -18,7 +18,7 @@ class PreparedCommand:
 
 
 class NativeCliAdapter:
-    """Adapter for direct CLI runtimes such as claude, codex, gemini, kimi, nanobot, qwen, opencode."""
+    """Adapter for direct CLI runtimes such as claude, codex, gemini, hermes, kimi, nanobot, qwen, opencode."""
 
     def prepare_command(
         self,
@@ -43,10 +43,19 @@ class NativeCliAdapter:
                 is_gemini_command(normalized_command)
                 or is_kimi_command(normalized_command)
                 or is_opencode_command(normalized_command)
+                or is_hermes_command(normalized_command)
             ):
                 final_command.append("--yolo")
 
-        if is_kimi_command(normalized_command):
+        if is_hermes_command(normalized_command):
+            # Hermes: ensure 'chat' subcommand, pass prompt via -q, session via --continue
+            if len(final_command) < 2 or final_command[1] != "chat":
+                final_command.insert(1, "chat")
+            if agent_name and "--continue" not in final_command:
+                final_command.extend(["--continue", agent_name])
+            if prompt:
+                final_command.extend(["-q", prompt])
+        elif is_kimi_command(normalized_command):
             if cwd and not command_has_workspace_arg(normalized_command):
                 final_command.extend(["-w", cwd])
             if prompt:
@@ -158,6 +167,11 @@ def is_openclaw_command(command: list[str]) -> bool:
     return command_basename(command) == "openclaw"
 
 
+def is_hermes_command(command: list[str]) -> bool:
+    """Check if the command is a Hermes Agent CLI invocation."""
+    return command_basename(command) == "hermes"
+
+
 def is_interactive_cli(command: list[str]) -> bool:
     """Check if the command is a known interactive AI coding CLI."""
     return (
@@ -169,6 +183,7 @@ def is_interactive_cli(command: list[str]) -> bool:
         or is_qwen_command(command)
         or is_opencode_command(command)
         or is_openclaw_command(command)
+        or is_hermes_command(command)
     )
 
 

--- a/clawteam/spawn/adapters.py
+++ b/clawteam/spawn/adapters.py
@@ -48,11 +48,16 @@ class NativeCliAdapter:
                 final_command.append("--yolo")
 
         if is_hermes_command(normalized_command):
-            # Hermes: ensure 'chat' subcommand, tag as tool-sourced so clawteam
-            # spawns don't pollute the user's session list, pass prompt via -q.
+            # Hermes: tag as tool-sourced so clawteam spawns don't pollute the
+            # user's session list, pass prompt via -q. Insert 'chat' subcommand
+            # only when the user's original command is bare `hermes` (don't clobber
+            # user-supplied global options or alternate subcommands).
+            # Check normalized_command, not final_command, since skip_permissions
+            # may have already appended --yolo.
             # Do NOT pass --continue -- Hermes --continue resumes EXISTING sessions
             # only; fresh spawns auto-generate a session ID.
-            if len(final_command) < 2 or final_command[1] != "chat":
+            if len(normalized_command) == 1:
+                # Insert chat at position 1 (before any --yolo already appended).
                 final_command.insert(1, "chat")
             if "--source" not in final_command:
                 final_command.extend(["--source", "tool"])

--- a/clawteam/spawn/command_validation.py
+++ b/clawteam/spawn/command_validation.py
@@ -102,6 +102,11 @@ def is_opencode_command(command: list[str]) -> bool:
     return _cmd_basename(command) == "opencode"
 
 
+def is_hermes_command(command: list[str]) -> bool:
+    """Check if the command is a Hermes Agent CLI invocation."""
+    return _cmd_basename(command) == "hermes"
+
+
 def is_interactive_cli(command: list[str]) -> bool:
     """Check if the command is an interactive AI CLI."""
     return (
@@ -113,6 +118,7 @@ def is_interactive_cli(command: list[str]) -> bool:
         or is_kimi_command(command)
         or is_qwen_command(command)
         or is_opencode_command(command)
+        or is_hermes_command(command)
     )
 
 

--- a/clawteam/spawn/subprocess_backend.py
+++ b/clawteam/spawn/subprocess_backend.py
@@ -17,6 +17,7 @@ from clawteam.spawn.command_validation import (
     is_claude_command,
     is_codex_command,
     is_gemini_command,
+    is_hermes_command,
     is_kimi_command,
     is_nanobot_command,
     is_openclaw_command,
@@ -95,7 +96,7 @@ class SubprocessBackend(SpawnBackend):
                 final_command.append("--dangerously-skip-permissions")
             elif is_codex_command(normalized_command):
                 final_command.append("--dangerously-bypass-approvals-and-sandbox")
-            elif is_gemini_command(normalized_command) or is_kimi_command(normalized_command) or is_opencode_command(normalized_command):
+            elif is_gemini_command(normalized_command) or is_kimi_command(normalized_command) or is_opencode_command(normalized_command) or is_hermes_command(normalized_command):
                 final_command.append("--yolo")
         # Claude Code: pass --model if specified
         # Pass --model if specified (claude, openclaw)

--- a/clawteam/spawn/subprocess_backend.py
+++ b/clawteam/spawn/subprocess_backend.py
@@ -104,7 +104,22 @@ class SubprocessBackend(SpawnBackend):
             final_command.extend(["--model", model])
         if model and is_openclaw_command(normalized_command):
             final_command.extend(["--model", model])
-        if is_kimi_command(normalized_command):
+        # Hermes Agent: insert 'chat' only when the user's original command is
+        # bare `hermes` (don't clobber user-supplied global options or subcommands).
+        # Check normalized_command, not final_command, since skip_permissions
+        # may have already appended --yolo.
+        # Tag with --source tool so clawteam spawns don't pollute user session list.
+        # Pass prompt via -q (Hermes -p is --profile, not prompt).
+        if is_hermes_command(normalized_command):
+            if len(normalized_command) == 1:
+                final_command.insert(1, "chat")
+            if "--source" not in final_command:
+                final_command.extend(["--source", "tool"])
+            if model:
+                final_command.extend(["-m", model])
+            if prompt:
+                final_command.extend(["-q", prompt])
+        elif is_kimi_command(normalized_command):
             if cwd and not command_has_workspace_arg(normalized_command):
                 final_command.extend(["-w", cwd])
             if prompt:

--- a/clawteam/spawn/tmux_backend.py
+++ b/clawteam/spawn/tmux_backend.py
@@ -25,6 +25,7 @@ from clawteam.spawn.command_validation import (
     is_claude_command,
     is_codex_command,
     is_gemini_command,
+    is_hermes_command,
     is_kimi_command,
     is_nanobot_command,
     is_openclaw_command,
@@ -176,7 +177,7 @@ class TmuxBackend(SpawnBackend):
                 final_command.append("--dangerously-skip-permissions")
             elif is_codex_command(normalized_command):
                 final_command.append("--dangerously-bypass-approvals-and-sandbox")
-            elif is_gemini_command(normalized_command) or is_kimi_command(normalized_command) or is_opencode_command(normalized_command):
+            elif is_gemini_command(normalized_command) or is_kimi_command(normalized_command) or is_opencode_command(normalized_command) or is_hermes_command(normalized_command):
                 final_command.append("--yolo")
 
         # Claude Code: pass --model if specified
@@ -209,6 +210,18 @@ class TmuxBackend(SpawnBackend):
                     final_command.extend(["--agent", openclaw_agent])
                 if prompt:
                     final_command.extend(["--message", prompt])
+
+        # Hermes Agent: ensure 'chat' subcommand, pass prompt via -q, session via --continue
+        if is_hermes_command(normalized_command):
+            if final_command[0].endswith("hermes") and (len(final_command) == 1 or final_command[1] != "chat"):
+                final_command = [final_command[0], "chat"] + final_command[1:]
+            if agent_name and "--continue" not in final_command:
+                session_key = f"clawteam-{team_name}-{agent_name}"
+                final_command.extend(["--continue", session_key])
+            if model:
+                final_command.extend(["-m", model])
+            if prompt:
+                final_command.extend(["-q", prompt])
 
         if is_kimi_command(normalized_command):
             if cwd and not command_has_workspace_arg(normalized_command):
@@ -300,7 +313,7 @@ class TmuxBackend(SpawnBackend):
                 fallback_delay=cfg.spawn_prompt_delay,
             )
             _inject_prompt_via_buffer(target, agent_name, prompt)
-        elif prompt and not is_codex_command(normalized_command) and not is_openclaw_command(normalized_command) and not is_nanobot_command(normalized_command) and not is_gemini_command(normalized_command) and not is_kimi_command(normalized_command) and not is_qwen_command(normalized_command) and not is_opencode_command(normalized_command):
+        elif prompt and not is_codex_command(normalized_command) and not is_openclaw_command(normalized_command) and not is_hermes_command(normalized_command) and not is_nanobot_command(normalized_command) and not is_gemini_command(normalized_command) and not is_kimi_command(normalized_command) and not is_qwen_command(normalized_command) and not is_opencode_command(normalized_command):
             # Generic command: append prompt via send-keys
             _wait_for_tui_ready(
                 target,

--- a/clawteam/spawn/tmux_backend.py
+++ b/clawteam/spawn/tmux_backend.py
@@ -211,13 +211,15 @@ class TmuxBackend(SpawnBackend):
                 if prompt:
                     final_command.extend(["--message", prompt])
 
-        # Hermes Agent: ensure 'chat' subcommand, pass prompt via -q, session via --continue
+        # Hermes Agent: ensure 'chat' subcommand, tag as tool-sourced so clawteam
+        # spawns don't pollute the user's session list, pass prompt via -q.
+        # Do NOT pass --continue -- Hermes --continue resumes EXISTING sessions
+        # only; fresh spawns auto-generate a session ID.
         if is_hermes_command(normalized_command):
             if final_command[0].endswith("hermes") and (len(final_command) == 1 or final_command[1] != "chat"):
                 final_command = [final_command[0], "chat"] + final_command[1:]
-            if agent_name and "--continue" not in final_command:
-                session_key = f"clawteam-{team_name}-{agent_name}"
-                final_command.extend(["--continue", session_key])
+            if "--source" not in final_command:
+                final_command.extend(["--source", "tool"])
             if model:
                 final_command.extend(["-m", model])
             if prompt:

--- a/clawteam/spawn/tmux_backend.py
+++ b/clawteam/spawn/tmux_backend.py
@@ -211,13 +211,18 @@ class TmuxBackend(SpawnBackend):
                 if prompt:
                     final_command.extend(["--message", prompt])
 
-        # Hermes Agent: ensure 'chat' subcommand, tag as tool-sourced so clawteam
-        # spawns don't pollute the user's session list, pass prompt via -q.
+        # Hermes Agent: tag as tool-sourced so clawteam spawns don't pollute the
+        # user's session list, pass prompt via -q. Insert 'chat' subcommand
+        # only when the user's original command is bare `hermes` (don't clobber
+        # user-supplied global options or alternate subcommands).
+        # Check normalized_command, not final_command, since skip_permissions
+        # may have already appended --yolo.
         # Do NOT pass --continue -- Hermes --continue resumes EXISTING sessions
         # only; fresh spawns auto-generate a session ID.
         if is_hermes_command(normalized_command):
-            if final_command[0].endswith("hermes") and (len(final_command) == 1 or final_command[1] != "chat"):
-                final_command = [final_command[0], "chat"] + final_command[1:]
+            if len(normalized_command) == 1:
+                # Insert chat at position 1 (before any --yolo already appended).
+                final_command.insert(1, "chat")
             if "--source" not in final_command:
                 final_command.extend(["--source", "tool"])
             if model:

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from clawteam.spawn.adapters import (
     NativeCliAdapter,
     command_basename,
+    is_hermes_command,
     is_interactive_cli,
     is_opencode_command,
     is_qwen_command,
@@ -27,8 +28,14 @@ class TestCLIDetection:
         assert not is_opencode_command(["openai"])
         assert not is_opencode_command([])
 
+    def test_is_hermes_command(self):
+        assert is_hermes_command(["hermes"])
+        assert is_hermes_command(["/usr/local/bin/hermes"])
+        assert not is_hermes_command(["claude"])
+        assert not is_hermes_command([])
+
     def test_is_interactive_cli_covers_all_known(self):
-        for cmd in ["claude", "codex", "nanobot", "gemini", "kimi", "qwen", "opencode"]:
+        for cmd in ["claude", "codex", "nanobot", "gemini", "hermes", "kimi", "qwen", "opencode"]:
             assert is_interactive_cli([cmd]), f"{cmd} should be interactive"
 
     def test_is_interactive_cli_rejects_unknown(self):
@@ -112,3 +119,53 @@ class TestPrepareCommandPrompt:
         )
         assert result.post_launch_prompt is None
         assert "hello" in result.final_command
+
+
+class TestHermesCommandPreparation:
+    """Hermes Agent: chat subcommand insertion, -q prompt, --continue session, --yolo."""
+
+    adapter = NativeCliAdapter()
+
+    def test_hermes_gets_yolo(self):
+        result = self.adapter.prepare_command(
+            ["hermes"], skip_permissions=True, agent_name="w1",
+        )
+        assert "--yolo" in result.final_command
+        assert "chat" in result.final_command
+
+    def test_hermes_chat_subcommand_inserted(self):
+        result = self.adapter.prepare_command(["hermes"], agent_name="w1")
+        assert result.final_command[1] == "chat"
+
+    def test_hermes_no_duplicate_chat(self):
+        result = self.adapter.prepare_command(["hermes", "chat"], agent_name="w1")
+        assert result.final_command.count("chat") == 1
+
+    def test_hermes_prompt_via_q_flag(self):
+        result = self.adapter.prepare_command(
+            ["hermes"], prompt="do work", agent_name="w1",
+        )
+        assert "-q" in result.final_command
+        assert "do work" in result.final_command
+        assert result.post_launch_prompt is None
+
+    def test_hermes_continue_session(self):
+        result = self.adapter.prepare_command(
+            ["hermes"], agent_name="researcher",
+        )
+        assert "--continue" in result.final_command
+        assert "researcher" in result.final_command
+
+    def test_hermes_no_continue_without_agent_name(self):
+        result = self.adapter.prepare_command(["hermes"])
+        assert "--continue" not in result.final_command
+
+    def test_hermes_yolo_preserved_with_chat(self):
+        result = self.adapter.prepare_command(
+            ["hermes"], skip_permissions=True, agent_name="w1",
+        )
+        assert "--yolo" in result.final_command
+        assert "chat" in result.final_command
+        yolo_idx = result.final_command.index("--yolo")
+        chat_idx = result.final_command.index("chat")
+        assert chat_idx == 1  # chat at position 1

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -141,6 +141,25 @@ class TestHermesCommandPreparation:
         result = self.adapter.prepare_command(["hermes", "chat"], agent_name="w1")
         assert result.final_command.count("chat") == 1
 
+    def test_hermes_preserves_global_options(self):
+        # If user passes hermes with global options (e.g., --profile), we must
+        # NOT insert 'chat' and break the argv order. Hermes CLI shape is
+        # `hermes [global-options] <command>`.
+        result = self.adapter.prepare_command(
+            ["hermes", "--profile", "foo"], agent_name="w1",
+        )
+        # chat should NOT be injected when the user passed global options
+        assert "chat" not in result.final_command
+        # source tag should still apply
+        assert "--source" in result.final_command
+
+    def test_hermes_preserves_alternate_subcommand(self):
+        # If user passes a non-chat subcommand (e.g., `hermes sessions`),
+        # we must not rewrite it as `hermes chat sessions`.
+        result = self.adapter.prepare_command(["hermes", "sessions"], agent_name="w1")
+        assert result.final_command[1] == "sessions"
+        assert "chat" not in result.final_command
+
     def test_hermes_prompt_via_q_flag(self):
         result = self.adapter.prepare_command(
             ["hermes"], prompt="do work", agent_name="w1",

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -122,7 +122,7 @@ class TestPrepareCommandPrompt:
 
 
 class TestHermesCommandPreparation:
-    """Hermes Agent: chat subcommand insertion, -q prompt, --continue session, --yolo."""
+    """Hermes Agent: chat subcommand insertion, --source tool tag, -q prompt, --yolo."""
 
     adapter = NativeCliAdapter()
 
@@ -149,15 +149,17 @@ class TestHermesCommandPreparation:
         assert "do work" in result.final_command
         assert result.post_launch_prompt is None
 
-    def test_hermes_continue_session(self):
-        result = self.adapter.prepare_command(
-            ["hermes"], agent_name="researcher",
-        )
-        assert "--continue" in result.final_command
-        assert "researcher" in result.final_command
+    def test_hermes_tagged_as_tool_source(self):
+        # Hermes spawns from clawteam use --source tool so they don't
+        # pollute the user's session list (which defaults to cli)
+        result = self.adapter.prepare_command(["hermes"], agent_name="w1")
+        assert "--source" in result.final_command
+        assert "tool" in result.final_command
 
-    def test_hermes_no_continue_without_agent_name(self):
-        result = self.adapter.prepare_command(["hermes"])
+    def test_hermes_no_continue_flag(self):
+        # Hermes --continue resumes an existing session; clawteam spawns
+        # are fresh, so we must not pass --continue
+        result = self.adapter.prepare_command(["hermes"], agent_name="w1")
         assert "--continue" not in result.final_command
 
     def test_hermes_yolo_preserved_with_chat(self):
@@ -166,6 +168,5 @@ class TestHermesCommandPreparation:
         )
         assert "--yolo" in result.final_command
         assert "chat" in result.final_command
-        yolo_idx = result.final_command.index("--yolo")
         chat_idx = result.final_command.index("chat")
         assert chat_idx == 1  # chat at position 1

--- a/tests/test_spawn_backends.py
+++ b/tests/test_spawn_backends.py
@@ -1257,6 +1257,80 @@ def test_subprocess_backend_opencode_skip_permissions_and_prompt(monkeypatch, tm
     assert captured["cmd"][-4:] == ["opencode", "--yolo", "-p", "fix the bug"]
 
 
+def test_tmux_backend_hermes_chat_source_and_prompt(monkeypatch, tmp_path):
+    run_calls = _make_tmux_spawn_harness(monkeypatch, tmp_path, "hermes")
+
+    backend = TmuxBackend()
+    result = backend.spawn(
+        command=["hermes"],
+        agent_name="researcher",
+        agent_id="agent-h",
+        agent_type="general-purpose",
+        team_name="demo-team",
+        prompt="do research",
+        cwd="/tmp/demo",
+        skip_permissions=True,
+    )
+
+    assert "spawned" in result
+    new_session = next(c for c in run_calls if c[:3] == ["tmux", "new-session", "-d"])
+    full_cmd = new_session[-1]
+    # Verify: chat subcommand inserted, --yolo (skip_permissions), --source tool,
+    # -q prompt, and NO --continue (which only resumes existing sessions)
+    assert "hermes chat" in full_cmd
+    assert "--yolo" in full_cmd
+    assert "--source tool" in full_cmd
+    assert "-q 'do research'" in full_cmd
+    assert "--continue" not in full_cmd
+
+
+def test_subprocess_backend_hermes_chat_source_and_prompt(monkeypatch, tmp_path):
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    clawteam_bin = tmp_path / "venv" / "bin" / "clawteam"
+    clawteam_bin.parent.mkdir(parents=True)
+    clawteam_bin.write_text("#!/bin/sh\n")
+    monkeypatch.setattr(sys, "argv", [str(clawteam_bin)])
+
+    captured: dict[str, object] = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return DummyProcess()
+
+    monkeypatch.setattr(
+        "clawteam.spawn.command_validation.shutil.which",
+        lambda name, path=None: "/usr/bin/hermes" if name == "hermes" else None,
+    )
+    monkeypatch.setattr("clawteam.spawn.subprocess_backend.subprocess.Popen", fake_popen)
+    monkeypatch.setattr("clawteam.spawn.registry.register_agent", lambda **_: None)
+
+    backend = SubprocessBackend()
+    backend.spawn(
+        command=["hermes"],
+        agent_name="researcher",
+        agent_id="agent-h",
+        agent_type="general-purpose",
+        team_name="demo-team",
+        prompt="do research",
+        cwd="/tmp/demo",
+        skip_permissions=True,
+    )
+
+    cmd = captured["cmd"]
+    # Find the start of the agent command within the subprocess wrapper args
+    hermes_idx = cmd.index("hermes")
+    agent_cmd = cmd[hermes_idx:]
+    # Verify: chat subcommand, --yolo, --source tool, -q prompt (not -p!)
+    assert agent_cmd[:2] == ["hermes", "chat"]
+    assert "--yolo" in agent_cmd
+    assert "--source" in agent_cmd
+    assert "tool" in agent_cmd
+    assert "-q" in agent_cmd
+    assert "do research" in agent_cmd
+    # Must NOT use -p (that's --profile in Hermes)
+    assert "-p" not in agent_cmd
+
+
 # --- Gateway token propagation (issue #51) ---
 
 


### PR DESCRIPTION
## Summary

Adds first-class support for [Hermes Agent](https://github.com/NousResearch/hermes-agent) CLI as a spawn target in ClawTeam, alongside existing agents (OpenClaw, Claude, Codex, Gemini, Kimi, nanobot, Qwen, OpenCode).

After this merges: `clawteam spawn hermes --team my-team --agent-name researcher --task "..."` works end-to-end on both tmux and subprocess backends. Each spawned Hermes gets a tool-tagged session (so it doesn't pollute the user's session list), gbrain MCP access (since the parent's MCP config is inherited), and full worker isolation via git worktree + tmux window.

## What changed

**Core adapter support** (3 files):
- `clawteam/spawn/command_validation.py` -- `is_hermes_command()` detector, included in `is_interactive_cli()`
- `clawteam/spawn/adapters.py` -- Hermes case in `NativeCliAdapter.prepare_command()` (chat insertion, --source tool, --yolo, -q prompt)
- `clawteam/spawn/tmux_backend.py` -- Hermes case in `TmuxBackend.spawn()` (same flags + -m model forwarding)
- `clawteam/spawn/subprocess_backend.py` -- Hermes case in `SubprocessBackend.spawn()` (for Windows and explicit subprocess users)

**Tests** (2 files, 11 new tests):
- `tests/test_adapters.py` -- 9 unit tests: detection, chat insertion, --source tool, --yolo, prompt via -q, no --continue on fresh spawn, preservation of global options, preservation of alternate subcommands
- `tests/test_spawn_backends.py` -- 2 backend tests (tmux and subprocess) verifying the full spawn command shape

**Docs**:
- `README.md` -- Hermes added to the agents badge, prose list, and supported agents table

## How it works

When ClawTeam invokes `hermes`, the adapter builds:

```
hermes chat --yolo --source tool -q "<task>"
```

Key design decisions:

- **`chat` subcommand** inserted only when the user passes bare `hermes` (detected via `len(normalized_command) == 1`). Preserves global options like `--profile` and alternate subcommands like `sessions`, `model`, `setup`.
- **`--source tool`** tags the session so clawteam-spawned Hermes runs don't mix into the user's interactive session history (default is `--source cli`).
- **No `--continue`**. Hermes `--continue` only RESUMES existing sessions. Using it on a fresh spawn errors with "No session found". Fresh spawns let Hermes auto-generate the session ID.
- **`-q` not `-p`** for the prompt. In Hermes, `-p` is `--profile`, not prompt. This is the bug that broke subprocess backend before the codex-review fix.
- **`--yolo`** for `skip_permissions` (matches gemini/kimi/opencode pattern).
- **`-m`** for model routing (tmux/subprocess only; NativeCliAdapter has no `model` parameter by design).

## Review process

- **Claude Code review (/ce:review):** 6 reviewer agents in parallel (correctness, testing, maintainability, Python, CLI-readiness, adversarial). Caught the session naming inconsistency, chat insertion edge cases, and missing test coverage.
- **End-to-end testing in Hermes:** Caught that `--continue` errors on fresh sessions. Fixed by switching to `--source tool` and letting Hermes auto-generate IDs.
- **Codex independent review (/codex review):** Caught a P1 I missed: subprocess_backend had `--yolo` support but no command-building block, so it fell through to `-p prompt` (wrong flag for Hermes). Also caught blind chat insertion clobbering global options.

## Test results

```
474 passed, 9 skipped (full suite)
11 new Hermes-specific tests, all passing
Zero regressions to existing OpenClaw, Claude, Codex, Gemini, Kimi, nanobot, Qwen, or OpenCode paths
```

## Commits

1. `8f33764` feat: add Hermes Agent as native spawn target
2. `0ad24ce` fix: replace invalid --continue flag with --source tool for Hermes spawns (E2E test caught)
3. `cf74a6d` docs: add Hermes Agent to README supported agents
4. `569970e` fix: address codex review findings for Hermes adapter

## Test plan

- [ ] `python3 -m pytest tests/ --ignore=tests/test_gateway_integration.py` passes
- [ ] `clawteam spawn hermes --team demo --agent-name w1 --task "echo OK" --no-workspace` spawns a working Hermes in tmux
- [ ] `clawteam spawn subprocess hermes --team demo --agent-name w2 --task "echo OK" --no-workspace` spawns Hermes as a subprocess
- [ ] Spawned Hermes does not appear in `hermes sessions list` (due to `--source tool` tag)
- [ ] Existing OpenClaw spawn flows unchanged (verified by 39 passing tests for other agents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)