### PR TITLE
fix: OpenClaw 2026.6 spawn adaptation + respawn addressability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning follows [PEP 440](https://peps.python.org/pep-0440/) with `+openclaw`
 
 ### Added
 
+- **Auto-respawn for abnormal agent exits** — `trap EXIT` hook invokes `clawteam lifecycle on-exit`, which resets the agent's in-progress tasks to pending and respawns the agent (max 2 attempts, circuit-breaker tracked) when pending tasks remain ([#59](https://github.com/win4r/ClawTeam-OpenClaw/issues/59), [#60](https://github.com/win4r/ClawTeam-OpenClaw/pull/60))
+- **`subprocess_wrapper` keepalive recovery** for subprocess-backend workers ([#60](https://github.com/win4r/ClawTeam-OpenClaw/pull/60))
+- **Hermes Agent as native spawn target** — `chat` subcommand insertion, `--source tool` session tagging, `-q` prompt path, skill file with timing + routing guidance ([#63](https://github.com/win4r/ClawTeam-OpenClaw/issues/63))
+- **Docker nanobot runtime support** and keepalive recovery hardening (2026-04-14)
 - **Upstream sync 2026-05-28** — merged 197 upstream commits, including PR #154 (session capture/resume + leader watcher + runtime injection), keepalive subprocess worker recovery, generalized runtime injection for interactive backends, MCP support, harness/conductor/exit_journal scaffolding, multi-backend runtime resolution (`_resolve_runtime_backend`), `scalar_config_keys`, `format_timestamp`, gource board, profiles/hooks/plugins, and CJK README (`README_KR.md`).
 - **`is_pi_command` predicate** integrated into spawn validation and runtime injection paths.
 - **Skill injection via `--skill`** (claude-only `--append-system-prompt`).
@@ -22,6 +26,13 @@ Versioning follows [PEP 440](https://peps.python.org/pep-0440/) with `+openclaw`
 - Qwen now uses `--yolo` (consistent with Gemini/Kimi/Opencode/Hermes) instead of `--dangerously-skip-permissions`.
 - Gemini tmux interactive flag changed from `-p` to `-i`.
 
+### Fixed
+
+- **Bare `openclaw` spawn against OpenClaw ≥ 2026.6** — `openclaw agent` became a single-turn command requiring an explicit session target, so spawned workers exited immediately. Bare `openclaw` now normalizes to the resident `openclaw tui` form; the tmux backend supplies `--session`/`--message`/`--model` (verified live on OpenClaw 2026.6.11).
+- **Respawn no longer leaves duplicate same-name tmux windows** — spawn kills stale same-name windows first (never its own trap-handler window) and records the unique `#{window_id}` as the agent's tmux target, so name-based addressing can't go ambiguous.
+- **`runtime inject` now targets the window id recorded at spawn time** instead of the `session:window_name` form, keeping injection working after a respawn (live-verified: inject lands on the respawned agent).
+- **OpenClaw flag expansion is idempotent** — respawn re-runs the recorded command without duplicating `--session`/`--message`/`--model`/`--agent`.
+
 ### Fork-specific protections retained
 
 - Default agent remains `openclaw` (not `claude`).
@@ -34,6 +45,12 @@ Versioning follows [PEP 440](https://peps.python.org/pep-0440/) with `+openclaw`
 ### Known follow-ups (xfail)
 
 5 spawn-backend tests are marked `pytest.mark.xfail(strict=False)` because upstream PR #154's `build_keepalive_shell_command` / tmux `set-hook pane-exited` / docker-wrapped-nanobot path / `--append-system-prompt` ordering are not yet ported to fork's `subprocess_wrapper` / `trap EXIT` / manual-flag path. Tracked for a follow-up port. None of these block bot operation.
+
+### Known issues (from 2026-07-04 bot smoke test)
+
+- **Hard-killed agents lose conversation context on resume** — OpenClaw may not have flushed the session transcript when the process dies, so reconnecting with the same session key rotates to a fresh sessionId. Task-store recovery + identity re-injection still restore the working state. Mitigation direction: graceful termination before respawn.
+- **`clawteam session show` stays empty for openclaw agents** — the session locator inspects the command before flag expansion, so the exact `--session` key is never captured. OpenClaw resume does not depend on this record (deterministic session keys), cosmetic only.
+- **Idle `openclaw tui` workers may time out and exit** — long-lived teams should tune `agents.defaults.timeoutSeconds` (or accept worker churn + auto-respawn as the recovery path).
 
 ## [0.3.0+openclaw1] - 2026-04-04
 

--- a/clawteam/spawn/command_validation.py
+++ b/clawteam/spawn/command_validation.py
@@ -300,7 +300,11 @@ def normalize_spawn_command(command: list[str]) -> list[str]:
         if Path(remainder[0]).name.lower() == "nanobot" and len(remainder) == 1:
             return prefix + ["nanobot", "agent"]
     if executable == "openclaw" and len(command) == 1:
-        return [command[0], "agent", "--local"]
+        # OpenClaw >= 2026.6 made `openclaw agent` a single-turn command that
+        # requires an explicit session target, so a resident worker must run
+        # the interactive TUI instead. The tmux backend appends
+        # --session/--message/--model to bare `openclaw tui` commands.
+        return [command[0], "tui"]
 
     return list(command)
 

--- a/clawteam/spawn/subprocess_backend.py
+++ b/clawteam/spawn/subprocess_backend.py
@@ -129,7 +129,7 @@ class SubprocessBackend(SpawnBackend):
         # Pass --model if specified (claude, openclaw)
         if model and is_claude_command(normalized_command):
             final_command.extend(["--model", model])
-        if model and is_openclaw_command(normalized_command):
+        if model and is_openclaw_command(normalized_command) and "--model" not in final_command:
             final_command.extend(["--model", model])
         # Hermes Agent: insert 'chat' only when the user's original command is
         # bare `hermes` (don't clobber user-supplied global options or subcommands).

--- a/clawteam/spawn/tmux_backend.py
+++ b/clawteam/spawn/tmux_backend.py
@@ -225,31 +225,27 @@ class TmuxBackend(SpawnBackend):
         if model and is_claude_command(normalized_command):
             final_command.extend(["--model", model])
 
-        # OpenClaw TUI: pass --message for initial prompt and --session for isolation
+        # OpenClaw TUI: pass --message for initial prompt and --session for isolation.
+        # normalize_spawn_command() already expands bare `openclaw` to `openclaw tui`.
+        # Every flag is guarded so this stays idempotent: respawn_agent re-runs the
+        # recorded final_command, which already carries these flags.
         if is_openclaw_command(normalized_command):
             session_key = f"clawteam-{team_name}-{agent_name}"
-            if final_command[0].endswith("openclaw") and len(final_command) == 1:
-                final_command = [final_command[0], "tui", "--session", session_key]
-                if model:
+            if "tui" in final_command:
+                if "--session" not in final_command:
+                    final_command.extend(["--session", session_key])
+                if model and "--model" not in final_command:
                     final_command.extend(["--model", model])
-                if openclaw_agent:
+                if openclaw_agent and "--agent" not in final_command:
                     final_command.extend(["--agent", openclaw_agent])
-                if prompt:
-                    final_command.extend(["--message", prompt])
-            elif "tui" in final_command:
-                final_command.extend(["--session", session_key])
-                if model:
-                    final_command.extend(["--model", model])
-                if openclaw_agent:
-                    final_command.extend(["--agent", openclaw_agent])
-                if prompt:
+                if prompt and "--message" not in final_command:
                     final_command.extend(["--message", prompt])
             elif "agent" in final_command:
-                if model:
+                if model and "--model" not in final_command:
                     final_command.extend(["--model", model])
-                if openclaw_agent:
+                if openclaw_agent and "--agent" not in final_command:
                     final_command.extend(["--agent", openclaw_agent])
-                if prompt:
+                if prompt and "--message" not in final_command:
                     final_command.extend(["--message", prompt])
 
         # Hermes Agent: tag as tool-sourced so clawteam spawns don't pollute the
@@ -326,13 +322,19 @@ class TmuxBackend(SpawnBackend):
 
         if check.returncode != 0:
             launch = subprocess.run(
-                ["tmux", "new-session", "-d", "-s", session_name, "-n", agent_name, full_cmd],
+                ["tmux", "new-session", "-d", "-s", session_name, "-n", agent_name,
+                 "-P", "-F", "#{window_id}", full_cmd],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )
         else:
+            # Respawn safety: kill stale same-name windows first, otherwise
+            # name-based tmux addressing (session:window_name) becomes ambiguous
+            # and every downstream lookup (ready poll, inject, capture) fails.
+            _kill_stale_same_name_windows(session_name, agent_name)
             launch = subprocess.run(
-                ["tmux", "new-window", "-t", session_name, "-n", agent_name, full_cmd],
+                ["tmux", "new-window", "-t", session_name, "-n", agent_name,
+                 "-P", "-F", "#{window_id}", full_cmd],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )
@@ -340,6 +342,13 @@ class TmuxBackend(SpawnBackend):
         if launch.returncode != 0:
             stderr = launch.stderr.decode() if isinstance(launch.stderr, bytes) else launch.stderr
             return f"Error: failed to launch tmux session: {(stderr or '').strip()}"
+
+        # Prefer the unique window id (@N) printed by -P -F over the
+        # session:window_name form: window names are not unique, ids are.
+        launch_stdout = launch.stdout.decode() if isinstance(launch.stdout, bytes) else (launch.stdout or "")
+        window_id = launch_stdout.strip().splitlines()[-1].strip() if launch_stdout.strip() else ""
+        if window_id.startswith("@"):
+            target = window_id
 
         # Keep leader pane alive even if the agent process exits, so it can be
         # re-activated or inspected later (upstream PR #154 new feature).
@@ -457,7 +466,15 @@ class TmuxBackend(SpawnBackend):
         if not shutil.which("tmux"):
             return False, "tmux not installed"
 
+        # Prefer the unique window id recorded at spawn time; the
+        # session:window_name form breaks when duplicate names exist
+        # (e.g. after a respawn).
+        from clawteam.spawn.registry import get_agent_info
+
         target = f"{self.session_name(team)}:{agent_name}"
+        info = get_agent_info(team, agent_name)
+        if info and info.get("backend") == "tmux" and info.get("tmux_target"):
+            target = info["tmux_target"]
         probe = subprocess.run(
             ["tmux", "list-panes", "-t", target, "-F", "#{pane_id}"],
             capture_output=True,
@@ -612,6 +629,43 @@ def _startup_prompt_action(command: list[str], pane_text: str) -> str | None:
     if _looks_like_workspace_trust_prompt(command, pane_text):
         return "enter"
     return None
+
+
+def _kill_stale_same_name_windows(session_name: str, window_name: str) -> None:
+    """Kill leftover windows with the same name so name-based addressing stays unique.
+
+    Skips the window this process itself runs in: respawn executes inside the
+    dying agent's ``trap EXIT`` handler, and killing our own window would abort
+    the respawn mid-flight.
+    """
+    listing = subprocess.run(
+        ["tmux", "list-windows", "-t", session_name, "-F", "#{window_id} #{window_name}"],
+        capture_output=True,
+        text=True,
+    )
+    if listing.returncode != 0:
+        return
+    own_window_id = ""
+    own_pane = os.environ.get("TMUX_PANE", "")
+    if own_pane:
+        own = subprocess.run(
+            ["tmux", "display-message", "-p", "-t", own_pane, "#{window_id}"],
+            capture_output=True,
+            text=True,
+        )
+        if own.returncode == 0:
+            own_window_id = own.stdout.strip()
+    for line in listing.stdout.splitlines():
+        parts = line.split(None, 1)
+        if len(parts) != 2:
+            continue
+        window_id, name = parts
+        if name == window_name and window_id != own_window_id:
+            subprocess.run(
+                ["tmux", "kill-window", "-t", window_id],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
 
 
 def _wait_for_tmux_pane(

--- a/tests/test_openclaw_agent.py
+++ b/tests/test_openclaw_agent.py
@@ -31,6 +31,160 @@ def _make_tmux_mocks(monkeypatch, captured: dict, *, tmux_ok: bool = True, agent
     monkeypatch.setattr("clawteam.spawn.tmux_backend._confirm_workspace_trust_if_prompted", lambda *a, **kw: False)
 
 
+def test_normalize_bare_openclaw_to_tui():
+    """Bare `openclaw` must normalize to the resident TUI form, not the
+    single-turn `agent --local` form (OpenClaw >= 2026.6 exits immediately
+    without a session target)."""
+    from clawteam.spawn.command_validation import normalize_spawn_command
+
+    assert normalize_spawn_command(["openclaw"]) == ["openclaw", "tui"]
+    # Explicit subcommands must pass through untouched.
+    assert normalize_spawn_command(["openclaw", "tui"]) == ["openclaw", "tui"]
+    assert normalize_spawn_command(["openclaw", "agent", "--local"]) == [
+        "openclaw",
+        "agent",
+        "--local",
+    ]
+
+
+def test_tmux_backend_bare_openclaw_spawns_tui_with_session(monkeypatch):
+    """Bare `openclaw` spawn must run `openclaw tui` with per-agent --session
+    isolation and the task injected via --message."""
+    from clawteam.spawn.tmux_backend import TmuxBackend
+
+    captured: dict = {}
+    _make_tmux_mocks(monkeypatch, captured)
+
+    backend = TmuxBackend()
+    backend.spawn(
+        command=["openclaw"],
+        agent_name="w1",
+        agent_id="agent-tui",
+        agent_type="general-purpose",
+        team_name="reltest",
+        prompt="do the thing",
+        openclaw_agent=None,
+    )
+
+    spawn_cmd = captured.get("spawn_cmd", [])
+    full_shell_cmd = spawn_cmd[-1] if spawn_cmd else ""
+    openclaw_segment = next(
+        (seg for seg in full_shell_cmd.split(";") if "openclaw" in seg and "lifecycle" not in seg),
+        "",
+    )
+    assert " tui " in openclaw_segment or openclaw_segment.rstrip().endswith(" tui"), (
+        f"Expected 'openclaw tui' form, got: {openclaw_segment!r}"
+    )
+    assert "--session clawteam-reltest-w1" in openclaw_segment, (
+        f"Expected per-agent --session key, got: {openclaw_segment!r}"
+    )
+    assert "--message" in openclaw_segment, (
+        f"Expected task injected via --message, got: {openclaw_segment!r}"
+    )
+    assert "agent --local" not in openclaw_segment, (
+        f"Single-turn `agent --local` form must not be used: {openclaw_segment!r}"
+    )
+
+
+def test_tmux_backend_respawn_command_is_idempotent(monkeypatch):
+    """respawn_agent re-runs the recorded final_command, which already carries
+    --session/--message. The openclaw flag expansion must not append duplicates."""
+    from clawteam.spawn.tmux_backend import TmuxBackend
+
+    captured: dict = {}
+    _make_tmux_mocks(monkeypatch, captured)
+
+    backend = TmuxBackend()
+    backend.spawn(
+        command=[
+            "openclaw", "tui",
+            "--session", "clawteam-reltest-w1",
+            "--message", "recorded prompt",
+        ],
+        agent_name="w1",
+        agent_id="agent-r",
+        agent_type="general-purpose",
+        team_name="reltest",
+        prompt=None,
+        openclaw_agent=None,
+    )
+
+    spawn_cmd = captured.get("spawn_cmd", [])
+    full_shell_cmd = spawn_cmd[-1] if spawn_cmd else ""
+    assert full_shell_cmd.count("--session") == 1, (
+        f"--session must not be duplicated on respawn, got: {full_shell_cmd!r}"
+    )
+    assert full_shell_cmd.count("--message") == 1, (
+        f"--message must not be duplicated on respawn, got: {full_shell_cmd!r}"
+    )
+
+
+def test_kill_stale_same_name_windows_skips_own_window(monkeypatch):
+    """Stale same-name windows are killed, but never the window the current
+    process (the dying agent's trap handler) runs in."""
+    from clawteam.spawn.tmux_backend import _kill_stale_same_name_windows
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        result = MagicMock()
+        result.returncode = 0
+        if cmd[:2] == ["tmux", "list-windows"]:
+            result.stdout = "@1 w3\n@2 w3\n@3 other\n"
+        elif cmd[:2] == ["tmux", "display-message"]:
+            result.stdout = "@1\n"
+        else:
+            result.stdout = ""
+        return result
+
+    monkeypatch.setattr("clawteam.spawn.tmux_backend.subprocess.run", fake_run)
+    monkeypatch.setenv("TMUX_PANE", "%0")
+
+    _kill_stale_same_name_windows("clawteam-reltest", "w3")
+
+    killed = [c[-1] for c in calls if c[:2] == ["tmux", "kill-window"]]
+    assert killed == ["@2"], f"Expected only stale @2 killed (own @1 kept, @3 other name), got: {killed}"
+
+
+def test_inject_runtime_message_prefers_registry_target(monkeypatch):
+    """inject must address the precise window id recorded at spawn time, not the
+    ambiguous session:window_name form."""
+    from clawteam.spawn.tmux_backend import TmuxBackend
+
+    probed: list[str] = []
+
+    def fake_run(cmd, **kwargs):
+        result = MagicMock()
+        result.returncode = 0
+        if cmd[:2] == ["tmux", "list-panes"]:
+            probed.append(cmd[cmd.index("-t") + 1])
+            result.stdout = "%9\n"
+        else:
+            result.stdout = ""
+        return result
+
+    monkeypatch.setattr("clawteam.spawn.tmux_backend.shutil.which", lambda name: "/usr/bin/tmux")
+    monkeypatch.setattr("clawteam.spawn.tmux_backend.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "clawteam.spawn.registry.get_agent_info",
+        lambda team, agent: {"backend": "tmux", "tmux_target": "@7"},
+    )
+    monkeypatch.setattr(
+        "clawteam.spawn.tmux_backend._inject_prompt_via_buffer", lambda *a, **kw: None
+    )
+
+    backend = TmuxBackend()
+    envelope = MagicMock()
+    envelope.source, envelope.channel, envelope.priority = "system", "direct", "medium"
+    envelope.summary, envelope.evidence, envelope.recommended_next_action = "hi", [], None
+    envelope.message_type = "manual"
+    ok, status = backend.inject_runtime_message("reltest", "w3", envelope)
+
+    assert ok, f"inject should succeed, got: {status}"
+    assert probed == ["@7"], f"Expected probe against registry target @7, got: {probed}"
+
+
 def test_tmux_backend_includes_agent_flag_when_openclaw_agent_set(monkeypatch, capsys):
     """tmux_backend.spawn() with openclaw_agent='researcher' should include --agent researcher in command."""
     from clawteam.spawn.tmux_backend import TmuxBackend


### PR DESCRIPTION
## Summary

Release-prep fixes from the 2026-07-04 bot smoke test (the item left unchecked in #73's test plan, run against `openclaw-lancedb-test` / OpenClaw 2026.6.11). Two spawn-layer defects made OpenClaw workers unusable or unaddressable; both are fixed and live-verified. Full assessment: `~/Desktop/ClawTeam-PR/main-release-test/评估报告.md` (local).

## 一、Bare `openclaw` spawn dies instantly on OpenClaw ≥ 2026.6

### 问题
`openclaw agent` became a single-turn command requiring an explicit session target. The March-era normalize (`a4eb6ad`, `agent --local`) therefore spawns a worker that exits immediately (`Error: Pass --to ... to choose a session`) while spawn still reports OK. Not an upstream-merge regression — OpenClaw CLI drift vs fork integration.

### 改动
- `clawteam/spawn/command_validation.py`: bare `openclaw` → `["openclaw", "tui"]`; the tmux backend's existing TUI branch (5346540, 2026-03-18) supplies `--session`/`--message`/`--model`.

### 回归测试
- `test_normalize_bare_openclaw_to_tui`, `test_tmux_backend_bare_openclaw_spawns_tui_with_session` — the normalize special-case previously had zero coverage, which is why this went unnoticed.

## 二、Respawn leaves duplicate same-name windows → agent unaddressable

### 问题
Kill an agent with an in-progress task → auto-respawn (#60) fires inside the dying agent's `trap EXIT`. The old window is still open at that moment; spawn's ready check addresses `session:window_name`, goes ambiguous, returns Error; `spawn_with_retry` retries without rolling back → two live `w3` windows. From then on `runtime inject`/`watch` (upstream #154) can never address that agent (`tmux target not found`). Fork flagship feature × upstream new feature cross-defect.

### 改动
- `clawteam/spawn/tmux_backend.py`:
  - `new-session`/`new-window` capture the unique `#{window_id}` (`-P -F`) and record it as the agent's tmux target (registry + all in-spawn addressing)
  - spawn kills stale same-name windows first, skipping the current process's own window (respawn runs inside the trap handler — killing our own window would abort the respawn)
  - `inject_runtime_message` prefers the registry-recorded window id over `session:window_name`
  - OpenClaw flag expansion made idempotent (respawn re-runs the recorded `final_command`; no duplicated `--session`/`--message`)
- `clawteam/spawn/subprocess_backend.py`: same idempotency guard for `--model`

### 回归测试
- `test_tmux_backend_respawn_command_is_idempotent`, `test_kill_stale_same_name_windows_skips_own_window`, `test_inject_runtime_message_prefers_registry_target`

## 与现有架构的协作关系

```
┌────────────────────────────────────────────────────────────┐
│ spawn CLI (不变)                                            │
│   ↓                                                        │
│ normalize_spawn_command      【改：bare openclaw → tui】    │
│   ↓                                                        │
│ TmuxBackend.spawn                                          │
│   ├─ _kill_stale_same_name_windows   【本PR新增】           │
│   ├─ new-window -P -F "#{window_id}" 【改：拿唯一 id】      │
│   ├─ TUI flag expansion              【改：幂等 guard】     │
│   └─ register_agent(tmux_target=@N)  (函数不变，值变精确)    │
│   ↓                                                        │
│ trap EXIT → lifecycle on-exit → respawn_agent (不变)        │
│   ↓                                                        │
│ inject_runtime_message   【改：优先 registry 的 window id】  │
└────────────────────────────────────────────────────────────┘
```

## 兼容性评估

### ✅ 完全兼容
| 项目 | 说明 |
|------|------|
| registry schema | `tmux_target` 字段不变，只是值从 `session:name` 变为 `@N`（所有消费者经 tmux `-t` 使用，两种形式均合法） |
| session capture / locators | 读取 normalize 前的原始命令（upstream #154 设计），不受影响 |
| claude/codex/hermes/gemini 等其他 CLI | spawn 路径未触碰 |
| lifecycle on-exit / respawn_agent | 未修改；行为改善来自 spawn 层 |

### ⚠️ 需注意的行为变化
| 项目 | 影响 | 风险 |
|------|------|------|
| 同名 stale 窗口在 spawn 时被清理 | 死窗口尸体不再保留（leader 的 `remain-on-exit` 窗口不受影响——它们不与新 spawn 同名冲突时不会被碰；同名重 spawn 本就意味着替换） | 低 |
| spawn 输出的 target 显示为 `@N` | 日志/提示里的 target 形式变化 | 低 |

### ❌ 不存在的不兼容
- 不修改 config schema、CLI 参数、mailbox/task 协议
- 不修改 upstream #154 的 session persistence hooks

## Out of Scope（评估报告中的 follow-ups）
- 强杀场景 OpenClaw session 未 flush → resume 失忆（F4，外部依赖行为，缓解方向：优雅终止）
- `session show` 对 openclaw 恒为空（F5，capture 时机在参数展开前，记录性缺陷）
- idle tui 超时自退（F6，部署配置项）
- 5 个 xfail（upstream 路径未移植，沿用 #73 说明）

## 验证
- `ruff check clawteam/ tests/` — clean
- `pytest tests/` — **722 passed, 5 xfailed**（717 原有全绿 + 5 新增）
- 容器实测（OpenClaw 2026.6.11）：spawn 起活回话驻留（CT-TUI-OK）；kill 带任务 agent → 恰好 1 个新窗口 + inject 命中 respawn 后的 agent（INJECT-OK-99）

## 统计
```
5 files changed (+~200 insertions, -~40 deletions)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
